### PR TITLE
Expose service intents

### DIFF
--- a/opinions/opinions.go
+++ b/opinions/opinions.go
@@ -40,7 +40,7 @@ func (os Opinions) Apply(ctx context.Context, podSpec *corev1.PodTemplateSpec, i
 		podSpec.Labels = map[string]string{}
 	}
 	for _, o := range os {
-		if o.Applicable == nil || o.Applicable(applied, imageMetadata) {
+		if o.Applicable(applied, imageMetadata) {
 			applied = append(applied, o.GetId())
 			if err := o.Apply(ctx, podSpec, imageMetadata); err != nil {
 				return nil, err
@@ -72,6 +72,9 @@ func (o *BasicOpinion) GetId() string {
 }
 
 func (o *BasicOpinion) Applicable(applied AppliedOpinions, metadata cnb.BuildMetadata) bool {
+	if o.ApplicableFunc == nil {
+		return true
+	}
 	return o.ApplicableFunc(applied, metadata)
 }
 

--- a/opinions/opinions.go
+++ b/opinions/opinions.go
@@ -23,19 +23,25 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-type Opinion struct {
-	Id         string
-	Applicable func(applied AppliedOpinions, imageMetadata cnb.BuildMetadata) bool
-	Apply      func(ctx context.Context, podSpec *corev1.PodTemplateSpec, metadata cnb.BuildMetadata) error
+type Opinion interface {
+	GetId() string
+	Applicable(applied AppliedOpinions, imageMetadata cnb.BuildMetadata) bool
+	Apply(ctx context.Context, podSpec *corev1.PodTemplateSpec, metadata cnb.BuildMetadata) error
 }
 
 type Opinions []Opinion
 
 func (os Opinions) Apply(ctx context.Context, podSpec *corev1.PodTemplateSpec, imageMetadata cnb.BuildMetadata) ([]string, error) {
 	applied := AppliedOpinions{}
+	if podSpec.Annotations == nil {
+		podSpec.Annotations = map[string]string{}
+	}
+	if podSpec.Labels == nil {
+		podSpec.Labels = map[string]string{}
+	}
 	for _, o := range os {
 		if o.Applicable == nil || o.Applicable(applied, imageMetadata) {
-			applied = append(applied, o.Id)
+			applied = append(applied, o.GetId())
 			if err := o.Apply(ctx, podSpec, imageMetadata); err != nil {
 				return nil, err
 			}
@@ -53,4 +59,22 @@ func (os AppliedOpinions) Has(id string) bool {
 		}
 	}
 	return false
+}
+
+type BasicOpinion struct {
+	Id             string
+	ApplicableFunc func(applied AppliedOpinions, metadata cnb.BuildMetadata) bool
+	ApplyFunc      func(ctx context.Context, podSpec *corev1.PodTemplateSpec, metadata cnb.BuildMetadata) error
+}
+
+func (o *BasicOpinion) GetId() string {
+	return o.Id
+}
+
+func (o *BasicOpinion) Applicable(applied AppliedOpinions, metadata cnb.BuildMetadata) bool {
+	return o.ApplicableFunc(applied, metadata)
+}
+
+func (o *BasicOpinion) Apply(ctx context.Context, podSpec *corev1.PodTemplateSpec, metadata cnb.BuildMetadata) error {
+	return o.ApplyFunc(ctx, podSpec, metadata)
 }


### PR DESCRIPTION
An intent is a capability that the application has that needs to be
fulfilled by the platform in order to take effect. For example, an
application that has a mysql driver probably expects to have credentials
for a mysql database bound.

This PR only exposes the intent, it does nothing to either provision an
appropriate service, or bind a provisioned service to the application.
Other tools or aspects of the platform will need to provide those
capabilities.

This change also flips Opinion from a struct to an interface to allow
for different types of opinions. The previous Opinion struct is now a
BasicOpinion. The new SpringBootServiceIntent is an Opinion that looks
for drivers for the service and exposes the intent as a label in a
consistent way.