### PR TITLE
Assume boot 2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # mononoke
 ![image](https://musicart.xboxlive.com/7/ac355100-0000-0000-0000-000000000002/504/image.jpg?w=800&h=600)
 
-Spring Boot Application Reconcilers for Kubernetes
+Experimental Spring Boot Application Reconcilers for Kubernetes
+
 
 ## Spring Boot opinions
-
 
 - `spring-boot`
   
@@ -50,6 +50,10 @@ Spring Boot Application Reconcilers for Kubernetes
     - path is `{boot:management.endpoints.web.base-path}/health/readiness`
     - port is the `management.server.port` boot property
     - scheme `http` by default, `https` when boot property `management.server.ssl.enabled` is true
+
+## Spring Boot service intents
+
+Service intents are an indicator that an application may want to connect to a particular type of service. Any given intent may be missing, required, optional or mutually exclusive with another service.
 
 - `service-intent-mysql`
 

--- a/README.md
+++ b/README.md
@@ -3,3 +3,85 @@
 
 Spring Boot Application Reconcilers for Kubernetes
 
+## Spring Boot opinions
+
+
+- `spring-boot`
+  
+  when image has `spring-boot` dependency
+
+  - add label `apps.mononoke.local/framework` with value `spring-boot`
+  - add annotation `boot.spring.io/version` with value `{boot-version}`
+
+- `spring-boot-graceful-shutdown`
+
+  when image has one of `spring-boot-starter-tomcat`, `spring-boot-starter-jetty`, `spring-boot-starter-reactor-netty` or `spring-boot-starter-undertow` dependencies
+
+  - default pod termination grace period to 30 seconds (this is the k8s default)
+  - default boot property `server.shutdown.grace-period` to 80% of the pod's termination grace period
+
+- `spring-web-port`
+
+  when image has `spring-web` dependency
+ 
+  - default boot property `server.port` to `8080`
+  - err if port is claimed by another container
+  - add container port for `server.port`, if not already set
+
+- `spring-boot-actuator`
+
+  when image has `spring-boot-actuator` dependency
+
+  - default boot property `management.server.port` to match `server.port`
+  - default boot property `management.endpoints.web.base-path` to `/actuator`
+  - add annotation `boot.spring.io/actuator` with value `{scheme}://:{port}{base-path}`
+    - scheme is `http` by default, `https` when boot property `management.server.ssl.enabled` is `true`
+
+- `spring-boot-actuator-probes`
+
+  when `spring-boot-actuator` opinion was applied and boot property `management.health.probes.enabled` is not disabled
+
+  - default liveness probe timings to initial delay of 30 seconds (only set if no liveness probe is defined)
+  - default liveness probe handler to HTTP GET
+    - path is `{boot:management.endpoints.web.base-path}/health/liveness`
+    - port is the `management.server.port` boot property
+    - scheme `http` by default, `https` when boot property `management.server.ssl.enabled` is true
+  - default readiness probe handler to HTTP GET
+    - path is `{boot:management.endpoints.web.base-path}/health/readiness`
+    - port is the `management.server.port` boot property
+    - scheme `http` by default, `https` when boot property `management.server.ssl.enabled` is true
+
+- `service-intent-mysql`
+
+  when image has one of `mysql-connector-java` or `r2dbc-mysql` dependencies
+  
+  - add label `services.mononoke.local/mysql` with the container's name
+  - add annotation `services.mononoke.local/mysql` with the driver dependency name and version
+
+- `service-intent-postgres`
+
+  when image has one of `postgresql` or `r2dbc-postgresql` dependencies
+  
+  - add label `services.mononoke.local/postgres` with the container's name
+  - add annotation `services.mononoke.local/postgres` with the driver dependency name and version
+
+- `service-intent-mongodb`
+
+  when image has `mongodb-driver-core` dependency
+  
+  - add label `services.mononoke.local/mongodb` with the container's name
+  - add annotation `services.mononoke.local/mongodb` with the driver dependency name and version
+
+- `service-intent-rabbitmq`
+
+  when image has `amqp-client` dependency
+  
+  - add label `services.mononoke.local/rabbitmq` with the container's name
+  - add annotation `services.mononoke.local/rabbitmq` with the driver dependency name and version
+
+- `service-intent-redis`
+
+  when image has `jedis` dependency
+  
+  - add label `services.mononoke.local/redis` with the container's name
+  - add annotation `services.mononoke.local/redis` with the driver dependency name and version

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Spring Boot Application Reconcilers for Kubernetes
 
 - `spring-boot-graceful-shutdown`
 
-  when image has one of `spring-boot-starter-tomcat`, `spring-boot-starter-jetty`, `spring-boot-starter-reactor-netty` or `spring-boot-starter-undertow` dependencies
+  when image has one of `spring-boot-starter-tomcat`, `spring-boot-starter-jetty`, `spring-boot-starter-reactor-netty` or `spring-boot-starter-undertow` dependencies and `spring-boot` version 2.3+
 
   - default pod termination grace period to 30 seconds (this is the k8s default)
   - default boot property `server.shutdown.grace-period` to 80% of the pod's termination grace period
@@ -39,7 +39,7 @@ Spring Boot Application Reconcilers for Kubernetes
 
 - `spring-boot-actuator-probes`
 
-  when `spring-boot-actuator` opinion was applied and boot property `management.health.probes.enabled` is not disabled
+  when image has `spring-boot-actuator` dependency version 2.3+ and boot property `management.health.probes.enabled` is not disabled
 
   - default liveness probe timings to initial delay of 30 seconds (only set if no liveness probe is defined)
   - default liveness probe handler to HTTP GET

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/spring-cloud-incubator/mononoke
 go 1.13
 
 require (
+	github.com/Masterminds/semver v1.5.0
 	github.com/google/go-cmp v0.4.0
 	github.com/google/go-containerregistry v0.0.0-20200304201134-fcc8ea80e26f
 	github.com/projectriff/system v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbt
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20190822182118-27a4ced34534/go.mod h1:iroGtC8B3tQiqtds1l+mgk/BBOrxbqjH+eUfFQYRc14=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=

--- a/opinions/opinions.go
+++ b/opinions/opinions.go
@@ -81,3 +81,14 @@ func (o *BasicOpinion) Applicable(applied AppliedOpinions, metadata cnb.BuildMet
 func (o *BasicOpinion) Apply(ctx context.Context, podSpec *corev1.PodTemplateSpec, containerIdx int, metadata cnb.BuildMetadata) error {
 	return o.ApplyFunc(ctx, podSpec, containerIdx, metadata)
 }
+
+func findContainerPort(ps corev1.PodSpec, port int32) (string, *corev1.ContainerPort) {
+	for _, c := range ps.Containers {
+		for _, p := range c.Ports {
+			if p.ContainerPort == port {
+				return c.Name, &p
+			}
+		}
+	}
+	return "", nil
+}

--- a/opinions/spring_boot_opinions.go
+++ b/opinions/spring_boot_opinions.go
@@ -42,7 +42,7 @@ var SpringBoot = Opinions{
 			podSpec.Labels["apps.mononoke.local/framework"] = "spring-boot"
 			for _, d := range bootMetadata.Dependencies {
 				if d.Name == "spring-boot" {
-					podSpec.Labels["boot.spring.io/version"] = d.Version
+					podSpec.Annotations["boot.spring.io/version"] = d.Version
 					break
 				}
 			}
@@ -314,8 +314,8 @@ func (o *SpringBootServiceIntent) Apply(ctx context.Context, podSpec *corev1.Pod
 	bootMetadata := NewSpringBootBOMMetadata(metadata)
 	for _, d := range bootMetadata.Dependencies {
 		if o.Dependencies.Has(d.Name) {
-			podSpec.Labels[o.LabelName] = d.Name
-			podSpec.Labels[fmt.Sprintf("%s-version", o.LabelName)] = d.Version
+			podSpec.Labels[o.LabelName] = podSpec.Spec.Containers[containerIdx].Name
+			podSpec.Annotations[o.LabelName] = fmt.Sprintf("%s/%s", d.Name, d.Version)
 			break
 		}
 	}


### PR DESCRIPTION
We can leverage the proper readiness and liveness probe endpoints that
are now provided by Spring Boot 2.3. Also adding better defaulting and
use of existing values.

- dropping non-actuator based probes
- using default probe timings, except for the liveness initial delay
- moving actuator by default to use `server.port`, it will respect a
  custom `management.server.port` value
- handle ssl enabled actuator
- detect port conflicts. `server.port` defaults to 8080, if that port is
  claimed by a different container, the reconciler will err until the
  user picks a free port. As port declarations are informational,
  conflicts may still occurs at runtime if another container in the pod
  binds to a port that it didn't declare.

Refs https://spring.io/blog/2020/03/25/liveness-and-readiness-probes-with-spring-boot