### PR TITLE
Expose labels and annotations on the template and parent resource

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,8 +12,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-go@v1
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2-beta
       with:
         go-version: '1.13'
     - name: Install kubebuilder

--- a/api/v1alpha1/springbootapplication_resource.go
+++ b/api/v1alpha1/springbootapplication_resource.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2020 the original author or authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"github.com/spring-cloud-incubator/mononoke/opinions"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ opinions.Resource = &SpringBootApplication{}
+
+func (r *SpringBootApplication) PodTemplate() *corev1.PodTemplateSpec {
+	return r.Spec.Template
+}

--- a/controllers/springbootapplication_controller.go
+++ b/controllers/springbootapplication_controller.go
@@ -94,7 +94,7 @@ func SpringBootApplicationApplyOpinions(c controllers.Config) controllers.SubRec
 			if err != nil {
 				return err
 			}
-			applied, err := opinions.SpringBoot.Apply(ctx, parent.Spec.Template, containerIdx, imageMetadata)
+			applied, err := opinions.SpringBoot.Apply(ctx, parent, containerIdx, imageMetadata)
 			if err != nil {
 				return err
 			}

--- a/opinions/resource.go
+++ b/opinions/resource.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2020 the original author or authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package opinions
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type Resource interface {
+	metav1.ObjectMetaAccessor
+	PodTemplate() *corev1.PodTemplateSpec
+}
+
+// setAnnotation sets the annotation on both the resource and the resource's
+// PodTemplateSpec
+func setAnnotation(r Resource, key, value string) {
+	parent := r.GetObjectMeta().GetAnnotations()
+	if parent == nil {
+		parent = map[string]string{}
+		r.GetObjectMeta().SetAnnotations(parent)
+	}
+	parent[key] = value
+
+	template := r.PodTemplate().GetAnnotations()
+	if template == nil {
+		template = map[string]string{}
+		r.PodTemplate().SetAnnotations(template)
+	}
+	template[key] = value
+}
+
+// setLabel sets the label on both the resource and the resource's
+// PodTemplateSpec
+func setLabel(r Resource, key, value string) {
+	parent := r.GetObjectMeta().GetLabels()
+	if parent == nil {
+		parent = map[string]string{}
+		r.GetObjectMeta().SetLabels(parent)
+	}
+	parent[key] = value
+
+	template := r.PodTemplate().GetLabels()
+	if template == nil {
+		template = map[string]string{}
+		r.PodTemplate().SetLabels(template)
+	}
+	template[key] = value
+}

--- a/samples/petclinic-mysql.yaml
+++ b/samples/petclinic-mysql.yaml
@@ -7,11 +7,10 @@ spec:
   subject:
     apiVersion: apps/v1
     kind: Deployment
-    name: petclinic
-    # selector:
-    #   matchExpressions:
-    #   - key: services.mononoke.local/mysql
-    #     operator: Exists
+    selector:
+      matchExpressions:
+      - key: services.mononoke.local/mysql
+        operator: Exists
   provider:
     apiVersion: bindings.projectriff.io/v1alpha1
     kind: BindableService


### PR DESCRIPTION
Reworked the opinions to accept the resource instead of the
PodTemplateSpec contained within the resource. This makes the resource's
annotations and labels available to be managed.

A Resource interface limits the exposure of other fields on the
SpringBootApplication resource, as well as maintains decoupling between
the opinions and the SpringBootApplication to allow for other types of
resources and sets of opinions.